### PR TITLE
Update README.md for CSS Search Highlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This is a repo that may contain explainers from [Igalia](https://www.igalia.com)
 ## CSS
 
 * [CSS selector :has() pseudo class](/css/has/README.md)
+* [CSS Highlights for find-in-page](/css/active-search-inactive-search)/README.md)
 
 ## HTML / Custom Handlers
 


### PR DESCRIPTION
Adding a reference to the CSS FInd-in-page highlights explainer in the top level README.